### PR TITLE
Change database graph representation to a directed graph

### DIFF
--- a/lib/datamodel/datamodel.js
+++ b/lib/datamodel/datamodel.js
@@ -30,10 +30,8 @@ export class Datamodel {
           if (!this.tableExists(neighbor)) {
             throw new Error('invalid table ' + table.getTableName() + ' in relationship in datamodel definition')
           }
-          const outgoingEdge = new Edge(table, neighbor)
-          const incomingEdge = new Edge(neighbor, table)
-          this.graph.addEdge(table, neighbor, outgoingEdge)
-          this.graph.addEdge(neighbor, table, incomingEdge)
+          const edge = new Edge(table, neighbor)
+          this.graph.addEdge(table, neighbor, edge)
         }
       }
     }


### PR DESCRIPTION
Only add one edge between table neighbors to ensure that the graph representation of the database is a DAG as opposed to an undirected graph.