### PR TITLE
Delete member group

### DIFF
--- a/src/controllers/project-member-groups-controller.js
+++ b/src/controllers/project-member-groups-controller.js
@@ -1,4 +1,6 @@
 import * as service from '../services/project-member-groups-service.js'
+import sequelizeConn from '../util/db.js'
+import { models } from '../models/init-models.js'
 
 export async function getProjectGroups(req, res) {
   const projectId = req.params.projectId
@@ -11,6 +13,21 @@ export async function getProjectGroups(req, res) {
     console.error(`Error: Cannot fetch member groups for ${projectId}`, err)
     res.status(500).json({ message: 'Error while fetching member groups.' })
   }
+}
+
+export async function deleteGroup(req, res) {
+  const group_id = req.body.group_id
+  const transaction = await sequelizeConn.transaction()
+  await models.ProjectMemberGroup.destroy({
+    where: {
+      group_id: group_id,
+    },
+    transaction: transaction,
+    individualHooks: true,
+    user: req.user,
+  })
+  await transaction.commit()
+  res.status(200).json({ group_id: group_id })
 }
 
 function convertGroup(row) {

--- a/src/routes/project-member-groups-route.js
+++ b/src/routes/project-member-groups-route.js
@@ -4,5 +4,6 @@ import * as controller from '../controllers/project-member-groups-controller.js'
 const projectMemberGroupsRouter = express.Router({ mergeParams: true })
 
 projectMemberGroupsRouter.get('/', controller.getProjectGroups)
+projectMemberGroupsRouter.post('/delete', controller.deleteGroup)
 
 export default projectMemberGroupsRouter


### PR DESCRIPTION
Added deleteGroup method to project-member-controller and added API route to delete a member group. This allows the front end to delete a member group in the database.