### PR TITLE
Split fetching Matrices for published and unpublished projects

### DIFF
--- a/src/services/matrix-service.js
+++ b/src/services/matrix-service.js
@@ -6,8 +6,20 @@ export async function getMatrix(matrixId) {
   return models.Matrix.findByPk(matrixId)
 }
 
-// for published project detail dump
 export async function getMatrices(projectId) {
+  const [rows] = await sequelizeConn.query(
+    `
+      SELECT matrix_id, user_id, title, type
+      FROM matrices
+      WHERE project_id = ?`,
+    { replacements: [projectId] }
+  )
+
+  return rows
+}
+
+// for published project detail dump
+export async function getMatricesDetails(projectId) {
   const [rows] = await sequelizeConn.query(
     `
       SELECT matrix_id, user_id, title, type, matrix_doi

--- a/src/services/project-detail-service.js
+++ b/src/services/project-detail-service.js
@@ -97,7 +97,7 @@ export async function getProjectDetails(
 // for published project detail dump
 async function getProjectOverview(projectId, matrixMap, folioMap, documentMap) {
   const summary = await projectService.getProject(projectId)
-  const matrices = await matrixService.getMatrices(projectId)
+  const matrices = await matrixService.getMatricesDetails(projectId)
   const projectStats = await projectStatsService.getProjectStats(projectId)
   const taxas = await projectStatsService.getTaxaStats(projectId)
   const members = await projectStatsService.getMembersStats(projectId)


### PR DESCRIPTION
Split the code to fetch published and unpublished matrices

The https://github.com/tair/mb4-service/pull/152 changed getMatrices which is also used when fetching matrices for taxa page. The change drastically  increased the latency since it also fetches counts, published hits, and published downloads which is not needed for simply fetching matrices.

The fix is to split the logic for published and unpublished pages so that loading taxa is much faster.