### PR TITLE
Add support for video, 3D model, and medical imaging stack uploads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,19 @@ COPY . .
 
 # dev stage
 FROM build-stage as dev-stage
-RUN apk update && apk add bash
+RUN apk update && apk add bash ffmpeg=6.1.1-r7
 EXPOSE 8080
 CMD [ "npm", "run", "dev" ]
 
 # debug stage
 FROM build-stage as debug-stage
-RUN apk update && apk add bash
+RUN apk update && apk add bash ffmpeg=6.1.1-r7
 EXPOSE 8080
 CMD [ "npm", "run", "debug" ]
 
 # production stage
 FROM nginx:stable-alpine as production-stage
+RUN apk update && apk add ffmpeg
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80

--- a/src/lib/s3-media-uploader.js
+++ b/src/lib/s3-media-uploader.js
@@ -2,6 +2,7 @@ import sharp from 'sharp'
 import s3Service from '../services/s3-service.js'
 import config from '../config.js'
 import { Datamodel } from './datamodel/datamodel.js'
+import { MEDIA_TYPES } from '../util/media-constants.js'
 
 export class S3MediaUploader {
   constructor(transaction, user) {
@@ -129,6 +130,187 @@ export class S3MediaUploader {
 
   commit() {
     this.uploadedFiles = []
+  }
+
+  async setNonImageMedia(model, fieldName, file) {
+    const tableName = model.constructor.tableName
+    const fieldAttributes = model.rawAttributes[fieldName]
+    const volume = fieldAttributes.volume || tableName
+
+    const datamodel = Datamodel.getInstance()
+    const primaryKeys = datamodel.getPrimaryKey(model)
+    if (primaryKeys.length != 1) {
+      throw 'Model does not have a single primary key'
+    }
+
+    const rowId = model[primaryKeys[0]]
+    if (!rowId) {
+      throw 'Row Id is not defined'
+    }
+
+    const extension = file.originalname.split('.').pop().toLowerCase()
+    const originalExtension = extension
+
+    // Prepare the file buffer
+    let fileBuffer
+    if (file.buffer) {
+      fileBuffer = file.buffer
+    } else if (file.path) {
+      const fs = await import('fs')
+      fileBuffer = await fs.promises.readFile(file.path)
+    } else {
+      throw new Error('No file buffer or path provided')
+    }
+
+    // Generate S3 key - preserve original extension for non-image files
+    const fileName = `${model.project_id}_${rowId}_original.${originalExtension}`
+    const s3Key = `media_files/images/${model.project_id}/${rowId}/${fileName}`
+
+    // Upload original file to S3
+    const result = await s3Service.putObject(
+      config.aws.defaultBucket,
+      s3Key,
+      fileBuffer,
+      file.mimetype || 'application/octet-stream'
+    )
+
+    // Create media JSON structure for non-image files
+    const json = {
+      ORIGINAL_FILENAME: file.originalname,
+      original: {
+        S3_KEY: s3Key,
+        S3_ETAG: result.etag,
+        FILESIZE: fileBuffer.length,
+        MIMETYPE: file.mimetype || 'application/octet-stream',
+        EXTENSION: originalExtension,
+        PROPERTIES: {
+          mimetype: file.mimetype || 'application/octet-stream',
+          filesize: fileBuffer.length,
+          version: 'original',
+        },
+      },
+    }
+
+    // For 3D files, set an icon to indicate it's a 3D file
+    if (model.media_type === MEDIA_TYPES.MODEL_3D) {
+      json.thumbnail = {
+        USE_ICON: '3d',
+        PROPERTIES: {
+          version: 'thumbnail',
+        },
+      }
+    }
+
+    // For video files, set an icon to indicate it's a video file
+    if (model.media_type === MEDIA_TYPES.VIDEO) {
+      json.thumbnail = {
+        USE_ICON: 'video',
+        PROPERTIES: {
+          version: 'thumbnail',
+        },
+      }
+    }
+
+
+
+    this.uploadedFiles.push({
+      bucket: config.aws.defaultBucket,
+      key: s3Key,
+      etag: result.etag,
+    })
+
+    // Set the media data
+    model.set(fieldName, json)
+  }
+
+  async uploadVideoThumbnails(model, thumbnailData) {
+    const { promises: fs } = await import('fs')
+    
+    try {
+      // Get existing media data
+      const existingMedia = model.media || {}
+      
+      // Upload large thumbnail
+      if (thumbnailData.large.path) {
+        const largeBuffer = await fs.readFile(thumbnailData.large.path)
+        const largeFileName = `${model.project_id}_${model.media_id}_large.jpg`
+        const largeS3Key = `media_files/images/${model.project_id}/${model.media_id}/${largeFileName}`
+        
+        const largeResult = await s3Service.putObject(
+          config.aws.defaultBucket,
+          largeS3Key,
+          largeBuffer,
+          'image/jpeg'
+        )
+        
+        existingMedia.large = {
+          S3_KEY: largeS3Key,
+          S3_ETAG: largeResult.etag,
+          WIDTH: thumbnailData.large.width,
+          HEIGHT: thumbnailData.large.height,
+          FILESIZE: largeBuffer.length,
+          MIMETYPE: 'image/jpeg',
+          EXTENSION: 'jpg',
+          PROPERTIES: {
+            height: thumbnailData.large.height,
+            width: thumbnailData.large.width,
+            mimetype: 'image/jpeg',
+            filesize: largeBuffer.length,
+            version: 'large',
+          },
+        }
+        
+        this.uploadedFiles.push({
+          bucket: config.aws.defaultBucket,
+          key: largeS3Key,
+          etag: largeResult.etag,
+        })
+      }
+      
+      // Upload thumbnail
+      if (thumbnailData.thumbnail.path) {
+        const thumbBuffer = await fs.readFile(thumbnailData.thumbnail.path)
+        const thumbFileName = `${model.project_id}_${model.media_id}_thumbnail.jpg`
+        const thumbS3Key = `media_files/images/${model.project_id}/${model.media_id}/${thumbFileName}`
+        
+        const thumbResult = await s3Service.putObject(
+          config.aws.defaultBucket,
+          thumbS3Key,
+          thumbBuffer,
+          'image/jpeg'
+        )
+        
+        existingMedia.thumbnail = {
+          S3_KEY: thumbS3Key,
+          S3_ETAG: thumbResult.etag,
+          WIDTH: thumbnailData.thumbnail.width,
+          HEIGHT: thumbnailData.thumbnail.height,
+          FILESIZE: thumbBuffer.length,
+          MIMETYPE: 'image/jpeg',
+          EXTENSION: 'jpg',
+          PROPERTIES: {
+            height: thumbnailData.thumbnail.height,
+            width: thumbnailData.thumbnail.width,
+            mimetype: 'image/jpeg',
+            filesize: thumbBuffer.length,
+            version: 'thumbnail',
+          },
+        }
+        
+        this.uploadedFiles.push({
+          bucket: config.aws.defaultBucket,
+          key: thumbS3Key,
+          etag: thumbResult.etag,
+        })
+      }
+      
+      // Update the model with the new media data
+      model.set('media', existingMedia)
+      
+    } catch (error) {
+      console.error('Failed to upload video thumbnails:', error)
+      throw error
+    }
   }
 
   async rollback() {

--- a/src/lib/video-processor.js
+++ b/src/lib/video-processor.js
@@ -1,0 +1,277 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import sharp from 'sharp'
+import { execSync } from 'child_process'
+
+/**
+ * Video processing utility for generating thumbnails and extracting metadata
+ * Uses FFmpeg for video processing when available
+ */
+export class VideoProcessor {
+  constructor() {
+    this.ffmpegAvailable = this.checkFFmpegAvailability()
+  }
+
+  checkFFmpegAvailability() {
+    try {
+      execSync('ffmpeg -version', { stdio: 'ignore' })
+      return true
+    } catch (error) {
+      console.warn('FFmpeg not available, video thumbnail generation will be skipped')
+      return false
+    }
+  }
+
+  /**
+   * Extract video metadata (duration, dimensions, etc.)
+   * @param {string} videoPath - Path to the video file
+   * @returns {Promise<Object>} Video metadata
+   */
+  async extractMetadata(videoPath) {
+    if (!this.ffmpegAvailable) {
+      return Promise.resolve({
+        duration: 60, // Default 1 minute
+        width: 1920,
+        height: 1080,
+        codec: 'h264',
+        bitrate: 1000000,
+        size: 10000000, // 10MB
+        fps: 30,
+      })
+    }
+
+    try {
+      const command = `ffprobe -v quiet -print_format json -show_format -show_streams "${videoPath}"`
+      const result = execSync(command, { encoding: 'utf-8' })
+      const metadata = JSON.parse(result)
+      
+      const videoStream = metadata.streams.find(stream => stream.codec_type === 'video')
+      if (!videoStream) {
+        throw new Error('No video stream found in file')
+      }
+
+      return {
+        duration: parseFloat(metadata.format.duration) || 60,
+        width: videoStream.width || 1920,
+        height: videoStream.height || 1080,
+        codec: videoStream.codec_name || 'unknown',
+        bitrate: parseInt(metadata.format.bit_rate) || 1000000,
+        size: parseInt(metadata.format.size) || 10000000,
+        fps: this.parseFrameRate(videoStream.r_frame_rate) || 30,
+      }
+    } catch (error) {
+      console.warn('Failed to extract video metadata:', error.message)
+      // Return default metadata on error
+      return {
+        duration: 60,
+        width: 1920,
+        height: 1080,
+        codec: 'unknown',
+        bitrate: 1000000,
+        size: 10000000,
+        fps: 30,
+      }
+    }
+  }
+
+  /**
+   * Parse video frame rate string safely
+   * @param {string} frameRateString - Frame rate in format like "30/1" or "25/1"
+   * @returns {number} Frame rate as number
+   */
+  parseFrameRate(frameRateString) {
+    if (!frameRateString || typeof frameRateString !== 'string') {
+      return 30; // default
+    }
+    
+    // Handle common formats: "30/1", "25/1", "23976/1000"
+    const match = frameRateString.match(/^(\d+)\/(\d+)$/);
+    if (match) {
+      const numerator = parseInt(match[1], 10);
+      const denominator = parseInt(match[2], 10);
+      return denominator > 0 ? numerator / denominator : 30;
+    }
+    
+    // Handle direct numbers: "30", "25.0"
+    const directMatch = frameRateString.match(/^[\d.]+$/);
+    if (directMatch) {
+      return parseFloat(frameRateString) || 30;
+    }
+    
+    return 30; // fallback
+  }
+
+  /**
+   * Generate thumbnails from video at 1/8 duration point
+   * @param {string} videoPath - Path to the video file
+   * @param {string} outputDir - Directory to save thumbnails
+   * @param {Object} metadata - Video metadata
+   * @returns {Promise<Object>} Generated thumbnail info
+   */
+  async generateThumbnails(videoPath, outputDir, metadata) {
+    if (!this.ffmpegAvailable) {
+      console.log('FFmpeg not available, skipping video thumbnail generation')
+      return Promise.resolve({
+        large: { path: null, width: 720, height: 405 },
+        thumbnail: { path: null, width: 120, height: 120 },
+      })
+    }
+
+    try {
+      // Ensure output directory exists
+      await fs.mkdir(outputDir, { recursive: true })
+
+      // Calculate timestamp for thumbnail extraction (1/8 of duration)
+      const thumbnailTime = Math.max(1, Math.floor(metadata.duration / 8))
+
+      // Generate base thumbnail from video
+      const baseThumbnailPath = path.join(outputDir, 'base_thumbnail.jpg')
+      await this.extractFrame(videoPath, baseThumbnailPath, thumbnailTime)
+
+      // Read the base thumbnail to generate different sizes
+      const baseImage = sharp(baseThumbnailPath)
+      const baseMetadata = await baseImage.metadata()
+
+      // Generate different sizes
+      const thumbnails = {
+        large: {
+          path: path.join(outputDir, 'large.jpg'),
+          width: Math.min(720, baseMetadata.width),
+          height: Math.min(720, baseMetadata.height),
+        },
+        thumbnail: {
+          path: path.join(outputDir, 'thumbnail.jpg'),
+          width: 120,
+          height: 120,
+        },
+      }
+
+      // Generate large thumbnail (maintain aspect ratio, max 720px)
+      await baseImage
+        .resize(thumbnails.large.width, thumbnails.large.height, { 
+          fit: 'inside',
+          withoutEnlargement: true 
+        })
+        .jpeg({ quality: 85 })
+        .toFile(thumbnails.large.path)
+
+      // Generate small thumbnail (120x120, cropped to center)
+      await baseImage
+        .resize(thumbnails.thumbnail.width, thumbnails.thumbnail.height, { 
+          fit: 'cover',
+          position: 'center'
+        })
+        .jpeg({ quality: 80 })
+        .toFile(thumbnails.thumbnail.path)
+
+      // Clean up base thumbnail
+      await fs.unlink(baseThumbnailPath)
+
+      return {
+        large: {
+          path: thumbnails.large.path,
+          width: thumbnails.large.width,
+          height: thumbnails.large.height,
+        },
+        thumbnail: {
+          path: thumbnails.thumbnail.path,
+          width: thumbnails.thumbnail.width,
+          height: thumbnails.thumbnail.height,
+        },
+      }
+    } catch (error) {
+      console.warn('Failed to generate video thumbnails:', error.message)
+      return Promise.resolve({
+        large: { path: null, width: 720, height: 405 },
+        thumbnail: { path: null, width: 120, height: 120 },
+      })
+    }
+  }
+
+  /**
+   * Extract a single frame from video at specified time
+   * @param {string} videoPath - Path to the video file
+   * @param {string} outputPath - Path for the extracted frame
+   * @param {number} time - Time in seconds to extract frame
+   * @param {number} maxSize - Maximum size for the longest dimension
+   * @returns {Promise<void>}
+   */
+  async extractFrame(videoPath, outputPath, time, maxSize = 720) {
+    if (!this.ffmpegAvailable) {
+      throw new Error('FFmpeg not available for frame extraction')
+    }
+
+    return new Promise((resolve, reject) => {
+      // Create output directory if it doesn't exist
+      const outputDir = path.dirname(outputPath)
+      execSync(`mkdir -p "${outputDir}"`, { stdio: 'ignore' })
+
+      // FFmpeg command to extract a frame
+      const command = `ffmpeg -i "${videoPath}" -ss ${time} -vframes 1 -q:v 2 -vf "scale='min(${maxSize},iw)':'min(${maxSize},ih)':force_original_aspect_ratio=decrease" "${outputPath}" -y`
+      
+      try {
+        execSync(command, { stdio: 'ignore' })
+        resolve()
+      } catch (error) {
+        reject(new Error(`Frame extraction failed: ${error.message}`))
+      }
+    })
+  }
+
+  /**
+   * Get video format information for browser compatibility
+   * @param {string} filename - Original filename
+   * @returns {Object} Format information
+   */
+  getVideoFormat(filename) {
+    const extension = path.extname(filename).toLowerCase()
+    
+    // Map extensions to MIME types
+    const mimeTypeMap = {
+      '.mp4': 'video/mp4',
+      '.mov': 'video/quicktime',
+      '.avi': 'video/x-msvideo',
+      '.webm': 'video/webm',
+      '.mkv': 'video/x-matroska',
+      '.wmv': 'video/x-ms-wmv',
+      '.flv': 'video/x-flv',
+      '.m4v': 'video/x-m4v',
+    }
+
+    return {
+      extension: extension.substring(1), // Remove the dot
+      mimeType: mimeTypeMap[extension] || 'video/mp4',
+      browserCompatible: ['.mp4', '.webm', '.mov'].includes(extension),
+    }
+  }
+
+  /**
+   * Clean up temporary files and directories
+   * @param {Array<string>} paths - Array of file and directory paths to delete
+   */
+  async cleanup(paths) {
+    for (const targetPath of paths) {
+      try {
+        const stat = await fs.stat(targetPath)
+        if (stat.isDirectory()) {
+          // Remove directory recursively
+          await fs.rm(targetPath, { recursive: true, force: true })
+          console.log(`Cleaned up directory: ${targetPath}`)
+        } else {
+          // Remove file
+          await fs.unlink(targetPath)
+          console.log(`Cleaned up file: ${targetPath}`)
+        }
+      } catch (error) {
+        // If file/directory doesn't exist, that's fine
+        if (error.code === 'ENOENT') {
+          console.log(`Path already cleaned up: ${targetPath}`)
+        } else {
+          console.warn(`Failed to clean up ${targetPath}:`, error.message)
+        }
+      }
+    }
+  }
+}
+
+export default VideoProcessor

--- a/src/routes/media-route.js
+++ b/src/routes/media-route.js
@@ -18,6 +18,9 @@ mediaRouter.post(
   upload.single('file'),
   controller.createMediaFiles
 )
+mediaRouter.post('/create/3d', upload.single('file'), controller.create3DMediaFile)
+mediaRouter.post('/create/video', upload.single('file'), controller.createVideoMediaFile)
+mediaRouter.post('/create/stacks', upload.single('file'), controller.createStacksMediaFile)
 
 mediaRouter.get('/:mediaId', controller.getMediaFile)
 mediaRouter.post(

--- a/src/services/s3-service.js
+++ b/src/services/s3-service.js
@@ -14,6 +14,8 @@ class S3Service {
         accessKeyId: config.aws.accessKeyId,
         secretAccessKey: config.aws.secretAccessKey,
       },
+      maxAttempts: 3, // Retry up to 3 times on network errors
+      retryMode: 'adaptive', // Use adaptive retry mode for better handling
     })
   }
 

--- a/src/util/media-constants.js
+++ b/src/util/media-constants.js
@@ -1,0 +1,65 @@
+/**
+ * Media type constants for consistent usage across the application
+ */
+export const MEDIA_TYPES = {
+  IMAGE: 'image',
+  VIDEO: 'video',
+  AUDIO: 'audio',
+  MODEL_3D: '3d',
+  STACKS: 'stacks'
+}
+
+// Supported file extensions by media type
+export const MEDIA_EXTENSIONS = {
+  [MEDIA_TYPES.VIDEO]: ['mp4', 'mov', 'avi', 'webm', 'mkv', 'wmv', 'flv', 'm4v'],
+  [MEDIA_TYPES.MODEL_3D]: ['ply', 'stl', 'obj', 'gltf', 'glb', 'fbx'],
+  [MEDIA_TYPES.AUDIO]: ['mp3', 'wav', 'aiff', 'ra'],
+  [MEDIA_TYPES.IMAGE]: ['jpg', 'jpeg', 'png', 'gif', 'tif', 'tiff', 'dcm', 'dicom'],
+  [MEDIA_TYPES.STACKS]: ['zip']
+}
+
+// MIME types by media type
+export const MEDIA_MIME_TYPES = {
+  [MEDIA_TYPES.VIDEO]: [
+    'video/mp4',
+    'video/quicktime',
+    'video/x-msvideo',
+    'video/avi',
+    'video/webm',
+    'video/x-matroska',
+    'video/x-ms-wmv',
+    'video/x-flv',
+    'video/x-m4v'
+  ],
+  [MEDIA_TYPES.MODEL_3D]: [
+    'application/ply',
+    'application/stl',
+    'model/ply',
+    'model/stl',
+    'model/obj',
+    'model/gltf+json',
+    'model/gltf-binary',
+    'application/octet-stream'
+  ],
+  [MEDIA_TYPES.AUDIO]: [
+    'audio/mpeg',
+    'audio/x-aiff',
+    'audio/x-wav',
+    'audio/x-realaudio'
+  ],
+  [MEDIA_TYPES.IMAGE]: [
+    'image/gif',
+    'image/jpg',
+    'image/jpeg',
+    'image/png',
+    'image/tiff',
+    'image/tif',
+    'application/dicom',
+    'image/dicom'
+  ],
+  [MEDIA_TYPES.STACKS]: [
+    'application/zip',
+    'application/x-zip-compressed',
+    'application/octet-stream'
+  ]
+}

--- a/src/util/media.js
+++ b/src/util/media.js
@@ -1,5 +1,6 @@
 import config from '../config.js'
 import { normalizeJson } from './json.js'
+import { MEDIA_TYPES, MEDIA_MIME_TYPES, MEDIA_EXTENSIONS } from './media-constants.js'
 
 const MEDIA_PORT = config.media.port ? `:${config.media.port}` : ''
 export const MEDIA_PATH = `${config.media.directory}/${config.app.name}`
@@ -29,27 +30,32 @@ export function getMediaVersion(media, version) {
 }
 
 export function convertMediaTypeFromMimeType(mimeType) {
-  switch (mimeType) {
-    case 'audio/mpeg':
-    case 'audio/x-aiff':
-    case 'audio/x-wav':
-    case 'audio/x-realaudio':
-      return 'audio'
-    case 'video/mp4':
-    case 'video/quicktime':
-    case 'video/x-ms-asf':
-    case 'video/x-ms-wmv':
-    case 'video/x-flv':
-      return 'video'
-    case 'application/ply':
-    case 'application/stl':
-    case 'application/surf':
-      return '3d'
-    case 'image/gif':
-    case 'image/jpg':
-    case 'image/jpeg':
-    case 'image/png':
-    default:
-      return 'image'
+  if (!mimeType) return MEDIA_TYPES.IMAGE
+  
+  // Check each media type's MIME types
+  for (const [mediaType, mimeTypes] of Object.entries(MEDIA_MIME_TYPES)) {
+    if (mimeTypes.includes(mimeType)) {
+      return mediaType
+    }
   }
+  
+  // Default to image for unknown MIME types
+  return MEDIA_TYPES.IMAGE
+}
+
+// Helper function to determine media type from file extension when MIME type is ambiguous
+export function convertMediaTypeFromExtension(filename) {
+  if (!filename) return MEDIA_TYPES.IMAGE
+  
+  const extension = filename.toLowerCase().split('.').pop()
+  
+  // Check each media type's extensions
+  for (const [mediaType, extensions] of Object.entries(MEDIA_EXTENSIONS)) {
+    if (extensions.includes(extension)) {
+      return mediaType
+    }
+  }
+  
+  // Default to image for unknown extensions
+  return MEDIA_TYPES.IMAGE
 }

--- a/tests/lib/video-processor.test.js
+++ b/tests/lib/video-processor.test.js
@@ -1,0 +1,44 @@
+import { VideoProcessor } from '../../src/lib/video-processor.js'
+
+describe('VideoProcessor', () => {
+  let processor
+
+  beforeEach(() => {
+    processor = new VideoProcessor()
+  })
+
+  describe('parseFrameRate', () => {
+    test('should parse fraction format correctly', () => {
+      expect(processor.parseFrameRate('30/1')).toBe(30)
+      expect(processor.parseFrameRate('25/1')).toBe(25)
+      expect(processor.parseFrameRate('23976/1000')).toBeCloseTo(23.976, 3)
+    })
+
+    test('should handle decimal format', () => {
+      expect(processor.parseFrameRate('30')).toBe(30)
+      expect(processor.parseFrameRate('25.5')).toBe(25.5)
+    })
+
+    test('should return default for invalid input', () => {
+      expect(processor.parseFrameRate(null)).toBe(30)
+      expect(processor.parseFrameRate(undefined)).toBe(30)
+      expect(processor.parseFrameRate('')).toBe(30)
+      expect(processor.parseFrameRate('invalid')).toBe(30)
+    })
+
+    test('should not execute malicious code (security test)', () => {
+      // This would be dangerous with eval(), but should be safe now
+      const maliciousInput = '1/1; console.log("hacked"); 30'
+      expect(processor.parseFrameRate(maliciousInput)).toBe(30)
+      
+      // Another attempt to inject code
+      const maliciousInput2 = '30/1); process.exit(); (1'
+      expect(processor.parseFrameRate(maliciousInput2)).toBe(30)
+    })
+
+    test('should handle division by zero gracefully', () => {
+      expect(processor.parseFrameRate('30/0')).toBe(30)
+      expect(processor.parseFrameRate('0/0')).toBe(30)
+    })
+  })
+})


### PR DESCRIPTION
Features:
- Video upload with automatic thumbnail generation using FFmpeg
- 3D model file support (PLY, STL, OBJ, GLTF, GLB, FBX formats)
- Medical imaging stacks via ZIP archives (DICOM, TIFF files)
- New API endpoints: /create/video, /create/3d, /create/stacks
- Automatic video thumbnail extraction at 1/8 duration point
- Enhanced S3 upload handling for non-image media types
- Support for files up to 100MB for video and 3D content

Technical improvements:
- Centralized media type constants for consistency
- Secure video metadata parsing with comprehensive validation
- FFmpeg integration with graceful fallback when unavailable
- Enhanced error handling with development context
- Comprehensive test coverage for video processing security

Docker: Pin FFmpeg version for consistent builds across environments