### PR TITLE
caching removed for constantly edited things like docs and media

### DIFF
--- a/src/controllers/document-controller.js
+++ b/src/controllers/document-controller.js
@@ -482,7 +482,7 @@ export async function serveDocumentFile(req, res) {
     res.set({
       'Content-Type': result.contentType || 'application/octet-stream',
       'Content-Length': result.contentLength,
-      'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
       'Last-Modified': result.lastModified,
       'Content-Disposition': `inline; filename="${originalFileName}"`,
     })

--- a/src/controllers/media-controller.js
+++ b/src/controllers/media-controller.js
@@ -969,7 +969,7 @@ export async function serveMediaFile(req, res) {
     res.set({
       'Content-Type': contentType,
       'Content-Length': result.contentLength,
-      'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
       'Last-Modified': result.lastModified,
     })
 


### PR DESCRIPTION
Edited documents and images show old files when downloaded or rendered in UI... this fixes that
[MB4-86](https://jira.phoenixbioinformatics.org/browse/MB4-86)