### PR TITLE
MB4-416: Fix json string parsing issue.

### DIFF
--- a/src/models/matrix.js
+++ b/src/models/matrix.js
@@ -168,8 +168,33 @@ export default class Matrix extends Model {
     )
   }
 
+  /**
+   * Some rows store other_options as a JSON string (driver/legacy/double-encoding).
+   * Normalize to a plain object before read/write.
+   */
+  ensureOtherOptionsObject() {
+    if (this.other_options == null) {
+      this.other_options = {}
+      return
+    }
+    if (typeof this.other_options === 'string') {
+      try {
+        const parsed = JSON.parse(this.other_options)
+        this.other_options =
+          parsed &&
+          typeof parsed === 'object' &&
+          !Array.isArray(parsed)
+            ? parsed
+            : {}
+      } catch {
+        this.other_options = {}
+      }
+    }
+  }
+
   getOption(key) {
-    if (this.other_options && this.other_options[key] !== undefined) {
+    this.ensureOtherOptionsObject()
+    if (this.other_options[key] !== undefined) {
       return this.other_options[key]
     }
     return 0 // Default value when option doesn't exist
@@ -177,9 +202,7 @@ export default class Matrix extends Model {
 
   setOption(key, value) {
     if (MATRIX_OPTIONS.includes(key)) {
-      if (!this.other_options) {
-        this.other_options = {}
-      }
+      this.ensureOtherOptionsObject()
       this.other_options[key] = value
       this.changed('other_options', true)
     }

--- a/src/models/matrix.js
+++ b/src/models/matrix.js
@@ -169,8 +169,36 @@ export default class Matrix extends Model {
   }
 
   /**
-   * Some rows store other_options as a JSON string (driver/legacy/double-encoding).
-   * Normalize to a plain object before read/write.
+   * Read-only view of other_options as a plain object. Does not mutate the
+   * model (avoids marking Sequelize rows dirty on read-only paths).
+   * Some rows store JSON as a string (legacy / client JSON.stringify).
+   */
+  getOtherOptionsSnapshot() {
+    const raw = this.other_options
+    if (raw == null) {
+      return {}
+    }
+    if (typeof raw === 'string') {
+      try {
+        const parsed = JSON.parse(raw)
+        if (
+          parsed &&
+          typeof parsed === 'object' &&
+          !Array.isArray(parsed)
+        ) {
+          return parsed
+        }
+      } catch {
+        /* ignore */
+      }
+      return {}
+    }
+    return raw
+  }
+
+  /**
+   * Normalize other_options to a mutable plain object before setOption writes.
+   * Call only when persisting changes.
    */
   ensureOtherOptionsObject() {
     if (this.other_options == null) {
@@ -193,9 +221,9 @@ export default class Matrix extends Model {
   }
 
   getOption(key) {
-    this.ensureOtherOptionsObject()
-    if (this.other_options[key] !== undefined) {
-      return this.other_options[key]
+    const opts = this.getOtherOptionsSnapshot()
+    if (opts[key] !== undefined) {
+      return opts[key]
     }
     return 0 // Default value when option doesn't exist
   }

--- a/src/models/matrix.js
+++ b/src/models/matrix.js
@@ -4,6 +4,21 @@ import { MATRIX_OPTIONS } from '../util/matrix.js'
 const { Model } = _sequelize
 
 export default class Matrix extends Model {
+  /**
+   * Normalize stored option values to integer flags (0/1) for matrix_options.
+   * Handles booleans and numeric strings; invalid values become 0.
+   */
+  static coerceMatrixOptionValue(v) {
+    if (v === undefined || v === null) {
+      return 0
+    }
+    if (typeof v === 'boolean') {
+      return v ? 1 : 0
+    }
+    const n = parseInt(v, 10)
+    return Number.isNaN(n) ? 0 : n
+  }
+
   static init(sequelize, DataTypes) {
     return super.init(
       {
@@ -222,10 +237,10 @@ export default class Matrix extends Model {
 
   getOption(key) {
     const opts = this.getOtherOptionsSnapshot()
-    if (opts[key] !== undefined) {
-      return opts[key]
+    if (opts[key] === undefined) {
+      return 0
     }
-    return 0 // Default value when option doesn't exist
+    return Matrix.coerceMatrixOptionValue(opts[key])
   }
 
   setOption(key, value) {

--- a/src/services/matrix-editor-service.js
+++ b/src/services/matrix-editor-service.js
@@ -5494,7 +5494,8 @@ export default class MatrixEditorService {
 
   getOptions() {
     const options = {}
-    if (this.matrix.other_options) {
+    this.matrix.ensureOtherOptionsObject()
+    if (this.matrix.other_options && Object.keys(this.matrix.other_options).length) {
       for (const key of MATRIX_OPTIONS) {
         options[key] = parseInt(this.matrix.other_options[key])
       }

--- a/src/services/matrix-editor-service.js
+++ b/src/services/matrix-editor-service.js
@@ -5494,17 +5494,8 @@ export default class MatrixEditorService {
 
   getOptions() {
     const options = {}
-    const opts = this.matrix.getOtherOptionsSnapshot()
     for (const key of MATRIX_OPTIONS) {
-      const v = opts[key]
-      if (v === undefined || v === null) {
-        options[key] = 0
-      } else if (typeof v === 'boolean') {
-        options[key] = v ? 1 : 0
-      } else {
-        const n = parseInt(v, 10)
-        options[key] = Number.isNaN(n) ? 0 : n
-      }
+      options[key] = this.matrix.getOption(key)
     }
     return options
   }

--- a/src/services/matrix-editor-service.js
+++ b/src/services/matrix-editor-service.js
@@ -5494,15 +5494,16 @@ export default class MatrixEditorService {
 
   getOptions() {
     const options = {}
-    this.matrix.ensureOtherOptionsObject()
-    if (this.matrix.other_options && Object.keys(this.matrix.other_options).length) {
-      for (const key of MATRIX_OPTIONS) {
-        options[key] = parseInt(this.matrix.other_options[key])
-      }
-    } else {
-      // Set default values when other_options is null
-      for (const key of MATRIX_OPTIONS) {
-        options[key] = 0 // Default to 0 for all options
+    const opts = this.matrix.getOtherOptionsSnapshot()
+    for (const key of MATRIX_OPTIONS) {
+      const v = opts[key]
+      if (v === undefined || v === null) {
+        options[key] = 0
+      } else if (typeof v === 'boolean') {
+        options[key] = v ? 1 : 0
+      } else {
+        const n = parseInt(v, 10)
+        options[key] = Number.isNaN(n) ? 0 : n
       }
     }
     return options


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `matrices.other_options` is read and normalized (including parsing legacy JSON strings) and alters defaults for missing/invalid option values, which could affect matrix option behavior for existing records.
> 
> **Overview**
> Fixes matrix option handling when `other_options` is stored as a JSON *string* or contains non-numeric values.
> 
> `Matrix.getOption()` now reads from a non-mutating snapshot that safely parses stringified JSON and coerces option values to integer flags (defaulting missing/invalid values to `0`), while `setOption()` normalizes `other_options` to an object before writing. `matrix-editor-service.getOptions()` is simplified to use `this.matrix.getOption()` for all `MATRIX_OPTIONS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7f71f0571e855a343d3436c1a370a89b19a66d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->