### PR TITLE
MB4-296: Guard against undefined cell values in matrix import

### DIFF
--- a/src/lib/matrix-import/matrix-importer.js
+++ b/src/lib/matrix-import/matrix-importer.js
@@ -827,7 +827,11 @@ function processCellValue(cellValue, params) {
     note = cellValue.note
     scores = cellValue.scores  // CSV parser creates polymorphic cells with 'scores' (plural)
   }
-  
+
+  if (scores == null || scores === '') {
+    return cells
+  }
+
   const isContinuous = character.type > 0
   
   if (isContinuous) {


### PR DESCRIPTION
## Summary
- Add null check in `processCellValue` before calling `toUpperCase` on cell scores
- Fixes crash when importing NEX files without character labels via the AI extractor fallback

## Test plan
- [ ] Upload a NEX file without CHARSTATELABELS on beta — should no longer crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an early-return guard in cell parsing to avoid calling string operations on null/undefined values; behavior change is limited to treating empty cells as no-op inserts.
> 
> **Overview**
> Prevents matrix imports from crashing when a cell’s `scores` value is `null`/`undefined`/empty by adding an early return in `processCellValue` before any string parsing (e.g., `toUpperCase`). Empty cells are now treated as producing no cell insertions rather than throwing during import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6dd0b590858ed403d31673622ad528802dcd85d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->