### PR TITLE
Release 20260420

### DIFF
--- a/src/controllers/publishing-controller.js
+++ b/src/controllers/publishing-controller.js
@@ -6,6 +6,7 @@ import sequelizeConn from '../util/db.js'
 import { processTasks } from '../services/task-queue-service.js'
 import config from '../config.js'
 import { buildAuthorsWithOrcid } from '../services/doi-author-service.js'
+import { isUserListedInArticleAuthors } from '../util/article-authors-eligibility.js'
 
 /**
  * Get publishing preferences form
@@ -527,18 +528,10 @@ export async function getOrcidWorkStatus(req, res) {
       return res.status(200).json({ orcidState: 'opted_out' })
     }
 
-    // Check if user's name appears in article_authors (matches handler eligibility)
     const project = await models.Project.findByPk(projectId, {
       attributes: ['article_authors'],
     })
-    const articleAuthors = (project?.article_authors || '').toLowerCase()
-    const fname = (user.fname || '').toLowerCase()
-    const lname = (user.lname || '').toLowerCase()
-    const nameInAuthors =
-      (fname && articleAuthors.includes(fname)) ||
-      (lname && articleAuthors.includes(lname))
-
-    if (!nameInAuthors) {
+    if (!isUserListedInArticleAuthors(user, project?.article_authors)) {
       return res.status(200).json({ orcidState: 'not_connected' })
     }
 

--- a/src/lib/data-cite-doi-creator.js
+++ b/src/lib/data-cite-doi-creator.js
@@ -22,19 +22,35 @@ export class DataCiteDOICreator {
   }
 
   async create(parameter) {
-    const content = this.generateJSON(parameter)
-    const fullDoi = `${this.shoulder}/${parameter.id}`
+    const content = this.generateJSON(parameter, { isUpdate: false })
+    return this._sendDoiMutation('POST', this.urlPath, content, parameter.id)
+  }
 
+  /**
+   * Update an existing DOI in DataCite (metadata refresh). Same path pattern as
+   * {@link exists} / MDS: `/dois/{shoulder}/{suffix}`.
+   */
+  async update(parameter) {
+    const content = this.generateJSON(parameter, { isUpdate: true })
+    const path = `${this.urlPath}/${this.shoulder}/${parameter.id}`
+    return this._sendDoiMutation('PUT', path, content, parameter.id)
+  }
+
+  _sendDoiMutation(method, path, content, idSuffix) {
+    const fullDoi = `${this.shoulder}/${idSuffix}`
     const options = {
       host: this.hostname,
-      path: this.urlPath,
-      method: 'POST',
+      path,
+      method,
       headers: {
         Authorization: this.authorizationToken,
         'Content-type': 'application/vnd.api+json',
       },
     }
+    return this._doJsonRequest(options, content, fullDoi)
+  }
 
+  async _doJsonRequest(options, content, fullDoi) {
     try {
       const response = await performRequest(options, content)
       const success = response.status < 300
@@ -75,7 +91,8 @@ export class DataCiteDOICreator {
     }
   }
 
-  generateJSON(parameter) {
+  generateJSON(parameter, options) {
+    const { isUpdate = false } = options || {}
     const date = new Date()
     const doi = `${this.shoulder}/${parameter.id}`
     const json = {
@@ -83,7 +100,7 @@ export class DataCiteDOICreator {
         id: doi,
         type: 'dois',
         attributes: {
-          event: 'publish',
+          event: isUpdate ? 'update' : 'publish',
           doi: doi,
           created: date.toISOString(), // E.g: "2016-09-19T21:53:56.000Z";
           publisher: 'MorphoBank',

--- a/src/lib/data-cite-doi-creator.js
+++ b/src/lib/data-cite-doi-creator.js
@@ -95,27 +95,32 @@ export class DataCiteDOICreator {
     const { isUpdate = false } = options || {}
     const date = new Date()
     const doi = `${this.shoulder}/${parameter.id}`
+    // DataCite only allows event: publish | register | hide. There is no "update".
+    // For metadata refresh (PUT), omit event; for new DOIs, publish to register as findable.
+    const attributes = {
+      doi: doi,
+      created: date.toISOString(), // E.g: "2016-09-19T21:53:56.000Z";
+      publisher: 'MorphoBank',
+      publicationYear: date.getFullYear(),
+      titles: [
+        {
+          title: parameter.title,
+        },
+      ],
+      types: {
+        resourceTypeGeneral: 'Dataset',
+      },
+      url: parameter.resource,
+      schemaVersion: 'http://datacite.org/schema/kernel-4',
+    }
+    if (!isUpdate) {
+      attributes.event = 'publish'
+    }
     const json = {
       data: {
         id: doi,
         type: 'dois',
-        attributes: {
-          event: isUpdate ? 'update' : 'publish',
-          doi: doi,
-          created: date.toISOString(), // E.g: "2016-09-19T21:53:56.000Z";
-          publisher: 'MorphoBank',
-          publicationYear: date.getFullYear(),
-          titles: [
-            {
-              title: parameter.title,
-            },
-          ],
-          types: {
-            resourceTypeGeneral: 'Dataset',
-          },
-          url: parameter.resource,
-          schemaVersion: 'http://datacite.org/schema/kernel-4',
-        },
+        attributes,
       },
     }
 

--- a/src/lib/task-handlers/doi-creation-handler.js
+++ b/src/lib/task-handlers/doi-creation-handler.js
@@ -79,35 +79,60 @@ export class DOICreationHandler extends Handler {
       : authorsSource.split(',').map((name) => name.trim())
     const projectDoiId = `P${projectId}`
     const projectTitle = `${project.name} (project)`
+    const projectResource = `${BASE_URL}/${projectId}/overview`
+    const projectPayload = {
+      id: projectDoiId,
+      user_id: userId,
+      authors: authors,
+      title: projectTitle,
+      resource: projectResource,
+    }
 
     const projectDoiExist = await this.doiCreator.exists(projectDoiId)
     let projectDoiToUpdate = null
 
     if (project.project_doi == null) {
       if (!projectDoiExist) {
-        // DOI doesn't exist, create it
-        const projectResource = `${BASE_URL}/${projectId}/overview`
-
-        const result = await this.doiCreator.create({
-          id: projectDoiId,
-          user_id: userId,
-          authors: authors,
-          title: projectTitle,
-          resource: projectResource,
-        })
+        const result = await this.doiCreator.create(projectPayload)
         if (!result.success) {
           return this.createError(
             HandlerErrors.HTTP_CLIENT_ERROR,
             `Error creating DOI: ${projectDoiId}`
           )
-        } else {
-          projectDoiToUpdate = result.doi
         }
+        projectDoiToUpdate = result.doi
       } else {
-        // DOI exists but database is null, construct full DOI for update
-        projectDoiToUpdate = `${this.doiCreator.shoulder}/${projectDoiId}`
+        const result = await this.doiCreator.update(projectPayload)
+        if (!result.success) {
+          return this.createError(
+            HandlerErrors.HTTP_CLIENT_ERROR,
+            `Error updating DOI: ${projectDoiId}`
+          )
+        }
+        projectDoiToUpdate = result.doi
       }
     } else {
+      if (projectDoiExist) {
+        const result = await this.doiCreator.update(projectPayload)
+        if (!result.success) {
+          return this.createError(
+            HandlerErrors.HTTP_CLIENT_ERROR,
+            `Error updating DOI: ${projectDoiId}`
+          )
+        }
+      } else {
+        const result = await this.doiCreator.create(projectPayload)
+        if (!result.success) {
+          return this.createError(
+            HandlerErrors.HTTP_CLIENT_ERROR,
+            `Error creating DOI: ${projectDoiId}`
+          )
+        }
+        projectDoiToUpdate = result.doi
+      }
+      if (projectDoiToUpdate == null) {
+        projectDoiToUpdate = project.project_doi
+      }
     }
 
     const matrixDois = new Map()
@@ -128,29 +153,34 @@ export class DOICreationHandler extends Handler {
       }
 
       const matrixDoiId = `X${matrixId}`
+      const matrixTitle = matrix.title ?? '(matrix)'
+      const matrixPayload = {
+        id: matrixDoiId,
+        user_id: userId,
+        authors: authors,
+        title: `${projectTitle} [X${matrixId}] ${matrixTitle}`,
+        resource: `${BASE_URL}/${projectId}/matrices/${matrixId}/view`,
+      }
+
       const doiExist = await this.doiCreator.exists(matrixDoiId)
       if (!doiExist) {
-        // DOI doesn't exist, create it
-        const matrixTitle = matrix.title ?? '(matrix)'
-        const result = await this.doiCreator.create({
-          id: matrixDoiId,
-          user_id: userId,
-          authors: authors,
-          title: `${projectTitle} [X${matrixId}] ${matrixTitle}`,
-          resource: `${BASE_URL}/${projectId}/matrices/${matrixId}/view`,
-        })
+        const result = await this.doiCreator.create(matrixPayload)
         if (!result.success) {
           return this.createError(
             HandlerErrors.HTTP_CLIENT_ERROR,
             `Error creating DOI: ${matrixDoiId}`
           )
-        } else {
-          matrixDois.set(matrixId, result.doi)
         }
+        matrixDois.set(matrixId, result.doi)
       } else {
-        // DOI exists but database is null, construct full DOI for update
-        const fullDoi = `${this.doiCreator.shoulder}/${matrixDoiId}`
-        matrixDois.set(matrixId, fullDoi)
+        const result = await this.doiCreator.update(matrixPayload)
+        if (!result.success) {
+          return this.createError(
+            HandlerErrors.HTTP_CLIENT_ERROR,
+            `Error updating DOI: ${matrixDoiId}`
+          )
+        }
+        matrixDois.set(matrixId, result.doi)
       }
     }
 

--- a/src/lib/task-handlers/doi-creation-handler.js
+++ b/src/lib/task-handlers/doi-creation-handler.js
@@ -4,6 +4,7 @@ import { Handler, HandlerErrors } from './handler.js'
 import { QueryTypes } from 'sequelize'
 import { models } from '../../models/init-models.js'
 import { updateProjectDoiAndRedump } from '../../services/publishing-service.js'
+import { buildAuthorsWithOrcid } from '../../services/doi-author-service.js'
 
 const BASE_URL = `${process.env.FRONTEND_URL}/project`
 
@@ -45,9 +46,26 @@ export class DOICreationHandler extends Handler {
       )
     }
 
+    // Task parameters snapshot authors at publish time; if empty (old tasks,
+    // bad snapshot, or edge case), rebuild from current project data.
+    let authorsSource = parameters.authors
+    const authorsMissingOrEmpty =
+      !authorsSource ||
+      (Array.isArray(authorsSource) && authorsSource.length === 0) ||
+      (typeof authorsSource === 'string' && !authorsSource.trim())
+    if (authorsMissingOrEmpty) {
+      const rebuilt = await buildAuthorsWithOrcid(project)
+      if (rebuilt.length > 0) {
+        console.warn(
+          `DOICreationHandler: empty authors in task parameters for project ${projectId}; rebuilt ${rebuilt.length} creator(s) from DB`
+        )
+        authorsSource = rebuilt
+      }
+    }
+
     if (
-      !parameters.authors ||
-      (Array.isArray(parameters.authors) && parameters.authors.length === 0)
+      !authorsSource ||
+      (Array.isArray(authorsSource) && authorsSource.length === 0)
     ) {
       return this.createError(
         HandlerErrors.ILLEGAL_PARAMETER,
@@ -56,9 +74,9 @@ export class DOICreationHandler extends Handler {
     }
 
     // Support both legacy comma-separated string and new [{name, orcid}] format
-    const authors = Array.isArray(parameters.authors)
-      ? parameters.authors
-      : parameters.authors.split(',').map((name) => name.trim())
+    const authors = Array.isArray(authorsSource)
+      ? authorsSource
+      : authorsSource.split(',').map((name) => name.trim())
     const projectDoiId = `P${projectId}`
     const projectTitle = `${project.name} (project)`
 

--- a/src/lib/task-handlers/orcid-works-handler.js
+++ b/src/lib/task-handlers/orcid-works-handler.js
@@ -1,10 +1,13 @@
 import sequelizeConn from '../../util/db.js'
 import { Handler, HandlerErrors } from './handler.js'
-import { QueryTypes } from 'sequelize'
 import { models } from '../../models/init-models.js'
 import { ORCIDWorksService } from '../orcid-works-service.js'
 import { time } from '../../util/util.js'
 import config from '../../config.js'
+import {
+  hasArticleAuthorsFilter,
+  isUserListedInArticleAuthors,
+} from '../../util/article-authors-eligibility.js'
 
 /**
  * Handler for pushing published project information to ORCID Works
@@ -82,13 +85,9 @@ export class ORCIDWorksHandler extends Handler {
     // Get article authors for filtering
     const articleAuthors = project.article_authors || ''
 
-    // Query eligible project members:
-    // - Have ORCID linked
-    // - Have access token
-    // - Are listed in article_authors (name appears in the authors string)
-    // Note: We no longer exclude admins/curators - if their name is in article_authors,
-    // they are legitimate authors and should get ORCID credit.
-    const eligibleMembersQuery = `
+    // Query project members with ORCID ready; author-list filter uses
+    // util/article-authors-eligibility.js (same as DOI creators + getOrcidWorkStatus).
+    const candidatesQuery = `
       SELECT DISTINCT u.user_id, u.orcid, u.orcid_access_token, u.fname, u.lname
       FROM projects_x_users AS pxu
       INNER JOIN ca_users AS u ON u.user_id = pxu.user_id
@@ -100,15 +99,18 @@ export class ORCIDWorksHandler extends Handler {
         AND u.orcid_write_access = 1
         AND u.orcid_opt_out = 0
         AND pxu.orcid_publish_opt_out = 0
-        AND (LOCATE(u.fname, ?) > 0 OR LOCATE(u.lname, ?) > 0)
     `
 
-    const [eligibleMembers] = await sequelizeConn.query(
-      eligibleMembersQuery,
-      {
-        replacements: [projectId, articleAuthors, articleAuthors],
-      }
-    )
+    const [candidates] = await sequelizeConn.query(candidatesQuery, {
+      replacements: [projectId],
+    })
+
+    const eligibleMembers =
+      hasArticleAuthorsFilter(articleAuthors) && candidates?.length
+        ? candidates.filter((row) =>
+            isUserListedInArticleAuthors(row, articleAuthors)
+          )
+        : []
 
     if (!eligibleMembers || eligibleMembers.length === 0) {
       return {

--- a/src/services/doi-author-service.js
+++ b/src/services/doi-author-service.js
@@ -2,24 +2,129 @@ import { models } from '../models/init-models.js'
 import {
   hasArticleAuthorsFilter,
   isUserListedInArticleAuthors,
+  parseArticleAuthorSegments,
 } from '../util/article-authors-eligibility.js'
 
 /**
- * Build a creators array from project members for DataCite DOI metadata.
- * Each member's name is included, and their ORCID is attached if they have one
- * and they haven't opted out of ORCID publishing.
+ * Build a creators array for DataCite DOI metadata.
  *
- * When article_authors is set, only members whose first or last name appears
- * in that string are included (same rule as ORCID). When article_authors is
- * blank, all members are included (backward-compatible; DOI still needs creators).
+ * When `article_authors` is set: one creator per parsed author in publication order
+ * (including non–MorphoBank authors as name-only). Project members are only used when
+ * their first or last name matches that author segment; then ORCID is added when
+ * allowed (same as before).
+ *
+ * When `article_authors` is empty: all project members in membership order; if there
+ * are no membership rows, the project owner.
  *
  * @param {Object} project - Project model instance
  * @returns {Array<{name: string, orcid?: string}>} Creators with optional ORCIDs
  */
 export async function buildAuthorsWithOrcid(project) {
   const rawArticleAuthors = project.article_authors
-  const filterByAuthorList = hasArticleAuthorsFilter(rawArticleAuthors)
 
+  if (!hasArticleAuthorsFilter(rawArticleAuthors)) {
+    return buildFromMembersUnfiltered(project)
+  }
+
+  const segments = parseArticleAuthorSegments(rawArticleAuthors)
+  if (segments.length === 0) {
+    return buildFromMembersUnfiltered(project)
+  }
+
+  return creatorsFromAuthorSegments(project, segments)
+}
+
+/**
+ * @param {Object} project
+ * @param {string[]} segments
+ */
+async function creatorsFromAuthorSegments(project, segments) {
+  const memberships = await models.ProjectsXUser.findAll({
+    where: { project_id: project.project_id },
+    attributes: ['user_id', 'orcid_publish_opt_out'],
+    raw: true,
+  })
+
+  let orderedUsers = []
+  const projectOptOuts = new Set()
+
+  if (memberships.length === 0) {
+    const owner = await models.User.findByPk(project.user_id, {
+      attributes: [
+        'user_id',
+        'fname',
+        'lname',
+        'orcid',
+        'orcid_opt_out',
+      ],
+      raw: true,
+    })
+    if (owner) {
+      const pxu = await models.ProjectsXUser.findOne({
+        where: { project_id: project.project_id, user_id: owner.user_id },
+        attributes: ['orcid_publish_opt_out'],
+        raw: true,
+      })
+      if (pxu?.orcid_publish_opt_out) {
+        projectOptOuts.add(owner.user_id)
+      }
+      orderedUsers = [owner]
+    }
+  } else {
+    const userIds = memberships.map((m) => m.user_id)
+    for (const m of memberships) {
+      if (m.orcid_publish_opt_out) {
+        projectOptOuts.add(m.user_id)
+      }
+    }
+    const users = await models.User.findAll({
+      where: { user_id: userIds },
+      attributes: ['user_id', 'fname', 'lname', 'orcid', 'orcid_opt_out'],
+      raw: true,
+    })
+    const userMap = new Map(users.map((u) => [u.user_id, u]))
+    orderedUsers = userIds
+      .map((id) => userMap.get(id))
+      .filter(Boolean)
+  }
+
+  const out = []
+  const usedUserIds = new Set()
+
+  for (const segment of segments) {
+    const s = (segment && String(segment).trim()) || ''
+    if (!s) {
+      continue
+    }
+    let matched = null
+    for (const u of orderedUsers) {
+      if (usedUserIds.has(u.user_id)) {
+        continue
+      }
+      if (isUserListedInArticleAuthors(u, s)) {
+        matched = u
+        usedUserIds.add(u.user_id)
+        break
+      }
+    }
+    if (matched) {
+      out.push(
+        creatorForMemberAndCitationName(
+          matched,
+          s,
+          projectOptOuts.has(matched.user_id)
+        )
+      )
+    } else {
+      out.push({ name: s })
+    }
+  }
+
+  return out.filter((c) => c.name)
+}
+
+/** @param {Object} project */
+async function buildFromMembersUnfiltered(project) {
   const memberships = await models.ProjectsXUser.findAll({
     where: { project_id: project.project_id },
     attributes: ['user_id', 'orcid_publish_opt_out'],
@@ -27,19 +132,16 @@ export async function buildAuthorsWithOrcid(project) {
   })
 
   if (memberships.length === 0) {
-    // Fallback to project owner
     const owner = await models.User.findByPk(project.user_id)
-    if (owner) {
-      if (
-        filterByAuthorList &&
-        !isUserListedInArticleAuthors(owner, rawArticleAuthors)
-      ) {
-        return []
-      }
-      const creator = buildCreator(owner)
-      return creator.name ? [creator] : []
+    if (!owner) {
+      return []
     }
-    return []
+    const c = creatorForMemberAndCitationName(
+      owner,
+      displayNameForUser(owner),
+      false
+    )
+    return c.name ? [c] : []
   }
 
   const userIds = memberships.map((m) => m.user_id)
@@ -48,30 +150,54 @@ export async function buildAuthorsWithOrcid(project) {
     attributes: ['user_id', 'fname', 'lname', 'orcid', 'orcid_opt_out'],
     raw: true,
   })
-
-  // Build a set of users who opted out at the project level
   const projectOptOuts = new Set(
     memberships.filter((m) => m.orcid_publish_opt_out).map((m) => m.user_id)
   )
-
-  // Preserve membership order (important for academic author ordering)
   const userMap = new Map(users.map((u) => [u.user_id, u]))
   return userIds
     .map((id) => userMap.get(id))
     .filter(Boolean)
-    .filter(
-      (user) =>
-        !filterByAuthorList ||
-        isUserListedInArticleAuthors(user, rawArticleAuthors)
+    .map((u) =>
+      creatorForMemberAndCitationName(
+        u,
+        displayNameForUser(u),
+        projectOptOuts.has(u.user_id)
+      )
     )
-    .map((user) => buildCreator(user, projectOptOuts.has(user.user_id)))
     .filter((c) => c.name)
 }
 
-function buildCreator(user, optedOut = false) {
-  const name = `${user.fname || ''} ${user.lname || ''}`.trim()
-  if (user.orcid && !optedOut && !user.orcid_opt_out) {
+/**
+ * Citation / display name in DOI: use the publication segment when the author is also a member;
+ * unfiltered path still uses the account "First Last" name.
+ * @param {Object} user
+ * @param {string} citationName
+ * @param {boolean} orcidProjectOptOut
+ * @returns {{ name: string, orcid?: string }}
+ */
+function creatorForMemberAndCitationName(
+  user,
+  citationName,
+  orcidProjectOptOut
+) {
+  const name = (citationName && citationName.trim()) || displayNameForUser(user)
+  if (!name) {
+    return { name: '' }
+  }
+  if (
+    user?.orcid &&
+    !orcidProjectOptOut &&
+    !user.orcid_opt_out
+  ) {
     return { name, orcid: user.orcid }
   }
   return { name }
+}
+
+/**
+ * @param {Object} user
+ * @returns {string}
+ */
+function displayNameForUser(user) {
+  return `${user.fname || ''} ${user.lname || ''}`.trim()
 }

--- a/src/services/doi-author-service.js
+++ b/src/services/doi-author-service.js
@@ -1,14 +1,25 @@
 import { models } from '../models/init-models.js'
+import {
+  hasArticleAuthorsFilter,
+  isUserListedInArticleAuthors,
+} from '../util/article-authors-eligibility.js'
 
 /**
  * Build a creators array from project members for DataCite DOI metadata.
  * Each member's name is included, and their ORCID is attached if they have one
  * and they haven't opted out of ORCID publishing.
  *
+ * When article_authors is set, only members whose first or last name appears
+ * in that string are included (same rule as ORCID). When article_authors is
+ * blank, all members are included (backward-compatible; DOI still needs creators).
+ *
  * @param {Object} project - Project model instance
  * @returns {Array<{name: string, orcid?: string}>} Creators with optional ORCIDs
  */
 export async function buildAuthorsWithOrcid(project) {
+  const rawArticleAuthors = project.article_authors
+  const filterByAuthorList = hasArticleAuthorsFilter(rawArticleAuthors)
+
   const memberships = await models.ProjectsXUser.findAll({
     where: { project_id: project.project_id },
     attributes: ['user_id', 'orcid_publish_opt_out'],
@@ -19,6 +30,12 @@ export async function buildAuthorsWithOrcid(project) {
     // Fallback to project owner
     const owner = await models.User.findByPk(project.user_id)
     if (owner) {
+      if (
+        filterByAuthorList &&
+        !isUserListedInArticleAuthors(owner, rawArticleAuthors)
+      ) {
+        return []
+      }
       const creator = buildCreator(owner)
       return creator.name ? [creator] : []
     }
@@ -42,6 +59,11 @@ export async function buildAuthorsWithOrcid(project) {
   return userIds
     .map((id) => userMap.get(id))
     .filter(Boolean)
+    .filter(
+      (user) =>
+        !filterByAuthorList ||
+        isUserListedInArticleAuthors(user, rawArticleAuthors)
+    )
     .map((user) => buildCreator(user, projectOptOuts.has(user.user_id)))
     .filter((c) => c.name)
 }

--- a/src/services/doi-author-service.js
+++ b/src/services/doi-author-service.js
@@ -6,29 +6,33 @@ import {
 } from '../util/article-authors-eligibility.js'
 
 /**
- * Build a creators array for DataCite DOI metadata.
+ * Placeholder DataCite `creator` when the project has no `article_authors` value.
+ */
+export const DOI_PLACEHOLDER_CREATOR_NAME = 'No authors available'
+
+/**
+ * Build the creators array for DataCite DOI metadata.
  *
- * When `article_authors` is set: one creator per parsed author in publication order
- * (including non–MorphoBank authors as name-only). Project members are only used when
- * their first or last name matches that author segment; then ORCID is added when
- * allowed (same as before).
+ * When `article_authors` is empty or missing: a single creator
+ * {@link DOI_PLACEHOLDER_CREATOR_NAME} (no project members).
  *
- * When `article_authors` is empty: all project members in membership order; if there
- * are no membership rows, the project owner.
+ * When `article_authors` is set: one creator per parsed segment in order; members
+ * match by name on each segment and get ORCIDs when allowed; non-matching segments
+ * are name-only (external authors).
  *
  * @param {Object} project - Project model instance
- * @returns {Array<{name: string, orcid?: string}>} Creators with optional ORCIDs
+ * @returns {Promise<Array<{ name: string, orcid?: string }>>}
  */
 export async function buildAuthorsWithOrcid(project) {
   const rawArticleAuthors = project.article_authors
 
   if (!hasArticleAuthorsFilter(rawArticleAuthors)) {
-    return buildFromMembersUnfiltered(project)
+    return [{ name: DOI_PLACEHOLDER_CREATOR_NAME }]
   }
 
   const segments = parseArticleAuthorSegments(rawArticleAuthors)
   if (segments.length === 0) {
-    return buildFromMembersUnfiltered(project)
+    return [{ name: DOI_PLACEHOLDER_CREATOR_NAME }]
   }
 
   return creatorsFromAuthorSegments(project, segments)
@@ -123,58 +127,6 @@ async function creatorsFromAuthorSegments(project, segments) {
   return out.filter((c) => c.name)
 }
 
-/** @param {Object} project */
-async function buildFromMembersUnfiltered(project) {
-  const memberships = await models.ProjectsXUser.findAll({
-    where: { project_id: project.project_id },
-    attributes: ['user_id', 'orcid_publish_opt_out'],
-    raw: true,
-  })
-
-  if (memberships.length === 0) {
-    const owner = await models.User.findByPk(project.user_id)
-    if (!owner) {
-      return []
-    }
-    const c = creatorForMemberAndCitationName(
-      owner,
-      displayNameForUser(owner),
-      false
-    )
-    return c.name ? [c] : []
-  }
-
-  const userIds = memberships.map((m) => m.user_id)
-  const users = await models.User.findAll({
-    where: { user_id: userIds },
-    attributes: ['user_id', 'fname', 'lname', 'orcid', 'orcid_opt_out'],
-    raw: true,
-  })
-  const projectOptOuts = new Set(
-    memberships.filter((m) => m.orcid_publish_opt_out).map((m) => m.user_id)
-  )
-  const userMap = new Map(users.map((u) => [u.user_id, u]))
-  return userIds
-    .map((id) => userMap.get(id))
-    .filter(Boolean)
-    .map((u) =>
-      creatorForMemberAndCitationName(
-        u,
-        displayNameForUser(u),
-        projectOptOuts.has(u.user_id)
-      )
-    )
-    .filter((c) => c.name)
-}
-
-/**
- * Citation / display name in DOI: use the publication segment when the author is also a member;
- * unfiltered path still uses the account "First Last" name.
- * @param {Object} user
- * @param {string} citationName
- * @param {boolean} orcidProjectOptOut
- * @returns {{ name: string, orcid?: string }}
- */
 function creatorForMemberAndCitationName(
   user,
   citationName,
@@ -184,20 +136,12 @@ function creatorForMemberAndCitationName(
   if (!name) {
     return { name: '' }
   }
-  if (
-    user?.orcid &&
-    !orcidProjectOptOut &&
-    !user.orcid_opt_out
-  ) {
+  if (user?.orcid && !orcidProjectOptOut && !user.orcid_opt_out) {
     return { name, orcid: user.orcid }
   }
   return { name }
 }
 
-/**
- * @param {Object} user
- * @returns {string}
- */
 function displayNameForUser(user) {
   return `${user.fname || ''} ${user.lname || ''}`.trim()
 }

--- a/src/util/article-authors-eligibility.js
+++ b/src/util/article-authors-eligibility.js
@@ -38,7 +38,9 @@ export function hasArticleAuthorsFilter(articleAuthorsRaw) {
 
 /**
  * Best-effort list of individual author name strings in publication order.
- * Splits on semicolons, newlines, and " and ".
+ * Splits on: semicolons, newlines, the word " and " (e.g. "A and B"), and commas
+ * (e.g. "Y. Mao, W. I. Ausich" → two authors). A single "Surname, Given" with no
+ * other commas is still split; use a semicolon to keep one byline that contains commas.
  *
  * @param {string|null|undefined} articleAuthorsRaw
  * @returns {string[]}
@@ -51,6 +53,7 @@ export function parseArticleAuthorSegments(articleAuthorsRaw) {
   return text
     .split(/(?:\s*;\s*|\n+)/)
     .flatMap((part) => part.split(/\s+and\s+/i))
+    .flatMap((part) => part.split(/,\s+/))
     .map((s) => s.trim())
     .filter(Boolean)
 }

--- a/src/util/article-authors-eligibility.js
+++ b/src/util/article-authors-eligibility.js
@@ -1,0 +1,33 @@
+/**
+ * Shared rules for "is this project member credited on the publication author line?"
+ * Used by DOI metadata, ORCID works, and publishing UI — keep behavior aligned here.
+ *
+ * Matching is case-insensitive; a user qualifies if their first or last name appears
+ * as a substring of article_authors (same idea as the legacy SQL LOCATE checks).
+ */
+
+/**
+ * @param {{ fname?: string|null, lname?: string|null }} user
+ * @param {string|null|undefined} articleAuthorsRaw
+ * @returns {boolean}
+ */
+export function isUserListedInArticleAuthors(user, articleAuthorsRaw) {
+  const articleAuthors = (articleAuthorsRaw || '').toLowerCase()
+  const fname = (user.fname || '').toLowerCase()
+  const lname = (user.lname || '').toLowerCase()
+  return (
+    (fname && articleAuthors.includes(fname)) ||
+    (lname && articleAuthors.includes(lname))
+  )
+}
+
+/**
+ * When false, DOI treats all members as creators (legacy / requires at least one creator).
+ * When true, only users passing {@link isUserListedInArticleAuthors} are included.
+ *
+ * @param {string|null|undefined} articleAuthorsRaw
+ * @returns {boolean}
+ */
+export function hasArticleAuthorsFilter(articleAuthorsRaw) {
+  return (articleAuthorsRaw || '').trim().length > 0
+}

--- a/src/util/article-authors-eligibility.js
+++ b/src/util/article-authors-eligibility.js
@@ -7,27 +7,49 @@
  */
 
 /**
+ * First or last name of `user` appears in the string (case-insensitive substring).
+ * Pass the full `article_authors` line, or a single {@link parseArticleAuthorSegments}
+ * segment, to test membership against that slice of the byline.
+ *
  * @param {{ fname?: string|null, lname?: string|null }} user
- * @param {string|null|undefined} articleAuthorsRaw
+ * @param {string|null|undefined} articleAuthorsOrSegment
  * @returns {boolean}
  */
-export function isUserListedInArticleAuthors(user, articleAuthorsRaw) {
-  const articleAuthors = (articleAuthorsRaw || '').toLowerCase()
+export function isUserListedInArticleAuthors(user, articleAuthorsOrSegment) {
+  const haystack = (articleAuthorsOrSegment || '').toLowerCase()
   const fname = (user.fname || '').toLowerCase()
   const lname = (user.lname || '').toLowerCase()
   return (
-    (fname && articleAuthors.includes(fname)) ||
-    (lname && articleAuthors.includes(lname))
+    (fname && haystack.includes(fname)) || (lname && haystack.includes(lname))
   )
 }
 
 /**
- * When false, DOI treats all members as creators (legacy / requires at least one creator).
- * When true, only users passing {@link isUserListedInArticleAuthors} are included.
+ * When true, the publication author line is present; DOI creators are derived from that
+ * string (see `parseArticleAuthorSegments` / `doi-author-service.js`).
  *
  * @param {string|null|undefined} articleAuthorsRaw
  * @returns {boolean}
  */
 export function hasArticleAuthorsFilter(articleAuthorsRaw) {
   return (articleAuthorsRaw || '').trim().length > 0
+}
+
+/**
+ * Best-effort list of individual author name strings in publication order.
+ * Splits on semicolons, newlines, and " and ".
+ *
+ * @param {string|null|undefined} articleAuthorsRaw
+ * @returns {string[]}
+ */
+export function parseArticleAuthorSegments(articleAuthorsRaw) {
+  const text = (articleAuthorsRaw || '').trim()
+  if (!text) {
+    return []
+  }
+  return text
+    .split(/(?:\s*;\s*|\n+)/)
+    .flatMap((part) => part.split(/\s+and\s+/i))
+    .map((s) => s.trim())
+    .filter(Boolean)
 }

--- a/src/util/article-authors-eligibility.js
+++ b/src/util/article-authors-eligibility.js
@@ -1,6 +1,7 @@
 /**
  * Shared rules for "is this project member credited on the publication author line?"
- * Used by DOI metadata, ORCID works, and publishing UI — keep behavior aligned here.
+ * Used by ORCID works, DOI metadata (when `article_authors` is set), and publishing UI.
+ * When `article_authors` is empty, `doi-author-service` uses a placeholder instead.
  *
  * Matching is case-insensitive; a user qualifies if their first or last name appears
  * as a substring of article_authors (same idea as the legacy SQL LOCATE checks).
@@ -25,8 +26,8 @@ export function isUserListedInArticleAuthors(user, articleAuthorsOrSegment) {
 }
 
 /**
- * When true, the publication author line is present; DOI creators are derived from that
- * string (see `parseArticleAuthorSegments` / `doi-author-service.js`).
+ * When true, the publication `article_authors` line is non-empty; used e.g. to filter
+ * ORCID work pushes and (with {@link parseArticleAuthorSegments}) DOI creator building.
  *
  * @param {string|null|undefined} articleAuthorsRaw
  * @returns {boolean}

--- a/tests/lib/data-cite-doi-creator.test.js
+++ b/tests/lib/data-cite-doi-creator.test.js
@@ -148,4 +148,22 @@ describe('DataCiteDOICreator.generateJSON', () => {
       'http://datacite.org/schema/kernel-4'
     )
   })
+
+  test('generateJSON uses event "publish" by default, "update" when requested', () => {
+    const instance = createTestInstance()
+    const created = JSON.parse(
+      instance.generateJSON(
+        { id: 'P1', title: 'T', resource: 'u', authors: [] },
+        { isUpdate: false }
+      )
+    )
+    const updated = JSON.parse(
+      instance.generateJSON(
+        { id: 'P1', title: 'T2', resource: 'u2', authors: [] },
+        { isUpdate: true }
+      )
+    )
+    expect(created.data.attributes.event).toBe('publish')
+    expect(updated.data.attributes.event).toBe('update')
+  })
 })

--- a/tests/lib/data-cite-doi-creator.test.js
+++ b/tests/lib/data-cite-doi-creator.test.js
@@ -149,7 +149,7 @@ describe('DataCiteDOICreator.generateJSON', () => {
     )
   })
 
-  test('generateJSON uses event "publish" by default, "update" when requested', () => {
+  test('generateJSON uses event "publish" for create; omits event on update (DataCite has no "update" event)', () => {
     const instance = createTestInstance()
     const created = JSON.parse(
       instance.generateJSON(
@@ -164,6 +164,6 @@ describe('DataCiteDOICreator.generateJSON', () => {
       )
     )
     expect(created.data.attributes.event).toBe('publish')
-    expect(updated.data.attributes.event).toBe('update')
+    expect(updated.data.attributes.event).toBeUndefined()
   })
 })

--- a/tests/services/doi-author-service.test.js
+++ b/tests/services/doi-author-service.test.js
@@ -8,6 +8,7 @@ jest.unstable_mockModule('models/init-models.js', () => ({
     },
     ProjectsXUser: {
       findAll: jest.fn(),
+      findOne: jest.fn(),
     },
   },
 }))
@@ -30,6 +31,7 @@ describe('buildAuthorsWithOrcid', () => {
     models.User.findByPk.mockReset()
     models.User.findAll.mockReset()
     models.ProjectsXUser.findAll.mockReset()
+    models.ProjectsXUser.findOne.mockReset()
   }
 
   test('returns project members with their ORCIDs', async () => {
@@ -161,7 +163,7 @@ describe('buildAuthorsWithOrcid', () => {
     ])
   })
 
-  test('when article_authors is set, includes only members listed in it', async () => {
+  test('when article_authors is set, lists every parsed author; members get ORCID when they match a segment', async () => {
     resetMocks()
     const project = {
       project_id: 900,
@@ -182,10 +184,11 @@ describe('buildAuthorsWithOrcid', () => {
 
     expect(result).toEqual([
       { name: 'John Smith', orcid: '0000-0001-1111-1111' },
+      { name: 'someone else' },
     ])
   })
 
-  test('when article_authors is set and no member matches, returns empty', async () => {
+  test('when article_authors is set and no member matches, uses citation names only (no project members in metadata)', async () => {
     resetMocks()
     const project = {
       project_id: 901,
@@ -202,19 +205,22 @@ describe('buildAuthorsWithOrcid', () => {
 
     const result = await buildAuthorsWithOrcid(project)
 
-    expect(result).toEqual([])
+    expect(result).toEqual([{ name: 'Only External Author' }])
   })
 
-  test('when article_authors is set, owner fallback requires name on author list', async () => {
+  test('no memberships: author list only, no project member in citation string (name-only creators)', async () => {
     resetMocks()
+    const authors = 'Someone Else (not the owner name)'
     const project = {
       project_id: 902,
       user_id: 5,
-      article_authors: 'Someone Else',
+      article_authors: authors,
     }
 
     models.ProjectsXUser.findAll.mockResolvedValue([])
+    models.ProjectsXUser.findOne.mockResolvedValue(null)
     models.User.findByPk.mockResolvedValue({
+      user_id: 5,
       fname: 'Owner',
       lname: 'Person',
       orcid: '0000-0005-5555-5555',
@@ -222,7 +228,7 @@ describe('buildAuthorsWithOrcid', () => {
 
     const result = await buildAuthorsWithOrcid(project)
 
-    expect(result).toEqual([])
+    expect(result).toEqual([{ name: authors }])
   })
 
   test('isUserListedInArticleAuthors matches ORCID-style substring check', () => {

--- a/tests/services/doi-author-service.test.js
+++ b/tests/services/doi-author-service.test.js
@@ -12,11 +12,14 @@ jest.unstable_mockModule('models/init-models.js', () => ({
   },
 }))
 
-let buildAuthorsWithOrcid, models
+let buildAuthorsWithOrcid, isUserListedInArticleAuthors, models
 
 beforeAll(async () => {
   const service = await import('services/doi-author-service.js')
   buildAuthorsWithOrcid = service.buildAuthorsWithOrcid
+
+  const eligibility = await import('util/article-authors-eligibility.js')
+  isUserListedInArticleAuthors = eligibility.isUserListedInArticleAuthors
 
   const modelsModule = await import('models/init-models.js')
   models = modelsModule.models
@@ -156,6 +159,76 @@ describe('buildAuthorsWithOrcid', () => {
       { name: 'John Smith', orcid: '0000-0001-1111-1111' },
       { name: 'Jane Doe' },
     ])
+  })
+
+  test('when article_authors is set, includes only members listed in it', async () => {
+    resetMocks()
+    const project = {
+      project_id: 900,
+      user_id: 1,
+      article_authors: 'John Smith and someone else',
+    }
+
+    models.ProjectsXUser.findAll.mockResolvedValue([
+      { user_id: 1, orcid_publish_opt_out: 0 },
+      { user_id: 2, orcid_publish_opt_out: 0 },
+    ])
+    models.User.findAll.mockResolvedValue([
+      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
+      { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: '0000-0002-2222-2222', orcid_opt_out: 0 },
+    ])
+
+    const result = await buildAuthorsWithOrcid(project)
+
+    expect(result).toEqual([
+      { name: 'John Smith', orcid: '0000-0001-1111-1111' },
+    ])
+  })
+
+  test('when article_authors is set and no member matches, returns empty', async () => {
+    resetMocks()
+    const project = {
+      project_id: 901,
+      user_id: 1,
+      article_authors: 'Only External Author',
+    }
+
+    models.ProjectsXUser.findAll.mockResolvedValue([
+      { user_id: 1, orcid_publish_opt_out: 0 },
+    ])
+    models.User.findAll.mockResolvedValue([
+      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
+    ])
+
+    const result = await buildAuthorsWithOrcid(project)
+
+    expect(result).toEqual([])
+  })
+
+  test('when article_authors is set, owner fallback requires name on author list', async () => {
+    resetMocks()
+    const project = {
+      project_id: 902,
+      user_id: 5,
+      article_authors: 'Someone Else',
+    }
+
+    models.ProjectsXUser.findAll.mockResolvedValue([])
+    models.User.findByPk.mockResolvedValue({
+      fname: 'Owner',
+      lname: 'Person',
+      orcid: '0000-0005-5555-5555',
+    })
+
+    const result = await buildAuthorsWithOrcid(project)
+
+    expect(result).toEqual([])
+  })
+
+  test('isUserListedInArticleAuthors matches ORCID-style substring check', () => {
+    const user = { fname: 'Jane', lname: 'Doe' }
+    expect(isUserListedInArticleAuthors(user, 'Doe, J.; Smith')).toBe(true)
+    expect(isUserListedInArticleAuthors(user, 'No match here')).toBe(false)
   })
 
   test('respects project-level orcid_publish_opt_out', async () => {

--- a/tests/services/doi-author-service.test.js
+++ b/tests/services/doi-author-service.test.js
@@ -122,3 +122,19 @@ describe('buildAuthorsWithOrcid', () => {
     expect(isUserListedInArticleAuthors(user, 'No match here')).toBe(false)
   })
 })
+
+describe('parseArticleAuthorSegments (comma lists)', () => {
+  test('splits typical comma + space author bylines for DOI', async () => {
+    const { parseArticleAuthorSegments } = await import(
+      'util/article-authors-eligibility.js'
+    )
+    const line = 'Y. Mao, W. I. Ausich, Y. Li, J. Lin, C. Lin'
+    expect(parseArticleAuthorSegments(line)).toEqual([
+      'Y. Mao',
+      'W. I. Ausich',
+      'Y. Li',
+      'J. Lin',
+      'C. Lin',
+    ])
+  })
+})

--- a/tests/services/doi-author-service.test.js
+++ b/tests/services/doi-author-service.test.js
@@ -13,11 +13,12 @@ jest.unstable_mockModule('models/init-models.js', () => ({
   },
 }))
 
-let buildAuthorsWithOrcid, isUserListedInArticleAuthors, models
+let buildAuthorsWithOrcid, DOI_PLACEHOLDER_CREATOR_NAME, isUserListedInArticleAuthors, models
 
 beforeAll(async () => {
   const service = await import('services/doi-author-service.js')
   buildAuthorsWithOrcid = service.buildAuthorsWithOrcid
+  DOI_PLACEHOLDER_CREATOR_NAME = service.DOI_PLACEHOLDER_CREATOR_NAME
 
   const eligibility = await import('util/article-authors-eligibility.js')
   isUserListedInArticleAuthors = eligibility.isUserListedInArticleAuthors
@@ -34,189 +35,44 @@ describe('buildAuthorsWithOrcid', () => {
     models.ProjectsXUser.findOne.mockReset()
   }
 
-  test('returns project members with their ORCIDs', async () => {
-    resetMocks()
-    const project = { project_id: 100, user_id: 1 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([
-      { user_id: 1 },
-      { user_id: 2 },
-    ])
-    models.User.findAll.mockResolvedValue([
-      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111' },
-      { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: '0000-0002-2222-2222' },
-    ])
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([
-      { name: 'John Smith', orcid: '0000-0001-1111-1111' },
-      { name: 'Jane Doe', orcid: '0000-0002-2222-2222' },
-    ])
+  test('when article_authors is missing, blank, or only whitespace, returns placeholder only', async () => {
+    const p1 = await buildAuthorsWithOrcid({ project_id: 1, user_id: 1 })
+    const p2 = await buildAuthorsWithOrcid({ project_id: 1, user_id: 1, article_authors: '' })
+    const p3 = await buildAuthorsWithOrcid({ project_id: 1, user_id: 1, article_authors: '   ' })
+    expect(p1).toEqual([{ name: DOI_PLACEHOLDER_CREATOR_NAME }])
+    expect(p2).toEqual([{ name: 'No authors available' }])
+    expect(p3).toEqual([{ name: 'No authors available' }])
   })
 
-  test('members without ORCID get name only', async () => {
-    resetMocks()
-    const project = { project_id: 200, user_id: 1 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([
-      { user_id: 1 },
-      { user_id: 2 },
-    ])
-    models.User.findAll.mockResolvedValue([
-      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111' },
-      { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: null },
-    ])
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([
-      { name: 'John Smith', orcid: '0000-0001-1111-1111' },
-      { name: 'Jane Doe' },
-    ])
-  })
-
-  test('falls back to project owner when no members', async () => {
-    resetMocks()
-    const project = { project_id: 300, user_id: 5 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([])
-    models.User.findByPk.mockResolvedValue({
-      fname: 'Owner',
-      lname: 'Person',
-      orcid: '0000-0005-5555-5555',
-    })
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([
-      { name: 'Owner Person', orcid: '0000-0005-5555-5555' },
-    ])
-  })
-
-  test('fallback owner without ORCID gets name only', async () => {
-    resetMocks()
-    const project = { project_id: 400, user_id: 6 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([])
-    models.User.findByPk.mockResolvedValue({
-      fname: 'No',
-      lname: 'Orcid',
-      orcid: null,
-    })
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([{ name: 'No Orcid' }])
-  })
-
-  test('returns empty array when no members and no owner', async () => {
-    resetMocks()
-    const project = { project_id: 500, user_id: 99 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([])
-    models.User.findByPk.mockResolvedValue(null)
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([])
-  })
-
-  test('filters out members with empty names', async () => {
-    resetMocks()
-    const project = { project_id: 600, user_id: 1 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([
-      { user_id: 1 },
-      { user_id: 2 },
-    ])
-    models.User.findAll.mockResolvedValue([
-      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111' },
-      { user_id: 2, fname: '', lname: '', orcid: '0000-0002-2222-2222' },
-    ])
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([
-      { name: 'John Smith', orcid: '0000-0001-1111-1111' },
-    ])
-  })
-
-  test('respects user-level orcid_opt_out', async () => {
-    resetMocks()
-    const project = { project_id: 700, user_id: 1 }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([
-      { user_id: 1 },
-      { user_id: 2 },
-    ])
-    models.User.findAll.mockResolvedValue([
-      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
-      { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: '0000-0002-2222-2222', orcid_opt_out: 1 },
-    ])
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([
-      { name: 'John Smith', orcid: '0000-0001-1111-1111' },
-      { name: 'Jane Doe' },
-    ])
-  })
-
-  test('when article_authors is set, lists every parsed author; members get ORCID when they match a segment', async () => {
+  test('with article_authors, matches members in segment order; ORCID when allowed', async () => {
     resetMocks()
     const project = {
-      project_id: 900,
+      project_id: 100,
       user_id: 1,
-      article_authors: 'John Smith and someone else',
+      article_authors: 'John Smith; Jane Doe',
     }
-
     models.ProjectsXUser.findAll.mockResolvedValue([
       { user_id: 1, orcid_publish_opt_out: 0 },
       { user_id: 2, orcid_publish_opt_out: 0 },
     ])
     models.User.findAll.mockResolvedValue([
-      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
-      { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: '0000-0002-2222-2222', orcid_opt_out: 0 },
+      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111' },
+      { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: null, orcid_opt_out: 0 },
     ])
-
     const result = await buildAuthorsWithOrcid(project)
-
     expect(result).toEqual([
       { name: 'John Smith', orcid: '0000-0001-1111-1111' },
-      { name: 'someone else' },
+      { name: 'Jane Doe' },
     ])
   })
 
-  test('when article_authors is set and no member matches, uses citation names only (no project members in metadata)', async () => {
+  test('no memberships: only owner can match a segment', async () => {
     resetMocks()
     const project = {
-      project_id: 901,
-      user_id: 1,
-      article_authors: 'Only External Author',
-    }
-
-    models.ProjectsXUser.findAll.mockResolvedValue([
-      { user_id: 1, orcid_publish_opt_out: 0 },
-    ])
-    models.User.findAll.mockResolvedValue([
-      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
-    ])
-
-    const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([{ name: 'Only External Author' }])
-  })
-
-  test('no memberships: author list only, no project member in citation string (name-only creators)', async () => {
-    resetMocks()
-    const authors = 'Someone Else (not the owner name)'
-    const project = {
-      project_id: 902,
+      project_id: 300,
       user_id: 5,
-      article_authors: authors,
+      article_authors: 'Owner Person',
     }
-
     models.ProjectsXUser.findAll.mockResolvedValue([])
     models.ProjectsXUser.findOne.mockResolvedValue(null)
     models.User.findByPk.mockResolvedValue({
@@ -225,36 +81,44 @@ describe('buildAuthorsWithOrcid', () => {
       lname: 'Person',
       orcid: '0000-0005-5555-5555',
     })
-
     const result = await buildAuthorsWithOrcid(project)
-
-    expect(result).toEqual([{ name: authors }])
+    expect(result).toEqual([{ name: 'Owner Person', orcid: '0000-0005-5555-5555' }])
   })
 
-  test('isUserListedInArticleAuthors matches ORCID-style substring check', () => {
-    const user = { fname: 'Jane', lname: 'Doe' }
-    expect(isUserListedInArticleAuthors(user, 'Doe, J.; Smith')).toBe(true)
-    expect(isUserListedInArticleAuthors(user, 'No match here')).toBe(false)
-  })
-
-  test('respects project-level orcid_publish_opt_out', async () => {
+  test('external-only byline: citation names without member match', async () => {
     resetMocks()
-    const project = { project_id: 800, user_id: 1 }
-
+    const project = { project_id: 901, user_id: 1, article_authors: 'Only External' }
     models.ProjectsXUser.findAll.mockResolvedValue([
       { user_id: 1, orcid_publish_opt_out: 0 },
-      { user_id: 2, orcid_publish_opt_out: 1 },
+    ])
+    models.User.findAll.mockResolvedValue([
+      { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
+    ])
+    const result = await buildAuthorsWithOrcid(project)
+    expect(result).toEqual([{ name: 'Only External' }])
+  })
+
+  test('John Smith and someone else: member + external segment', async () => {
+    resetMocks()
+    const project = { project_id: 900, user_id: 1, article_authors: 'John Smith and someone else' }
+    models.ProjectsXUser.findAll.mockResolvedValue([
+      { user_id: 1, orcid_publish_opt_out: 0 },
+      { user_id: 2, orcid_publish_opt_out: 0 },
     ])
     models.User.findAll.mockResolvedValue([
       { user_id: 1, fname: 'John', lname: 'Smith', orcid: '0000-0001-1111-1111', orcid_opt_out: 0 },
       { user_id: 2, fname: 'Jane', lname: 'Doe', orcid: '0000-0002-2222-2222', orcid_opt_out: 0 },
     ])
-
     const result = await buildAuthorsWithOrcid(project)
-
     expect(result).toEqual([
       { name: 'John Smith', orcid: '0000-0001-1111-1111' },
-      { name: 'Jane Doe' },
+      { name: 'someone else' },
     ])
+  })
+
+  test('isUserListedInArticleAuthors substring check', () => {
+    const user = { fname: 'Jane', lname: 'Doe' }
+    expect(isUserListedInArticleAuthors(user, 'Doe, J.; Smith')).toBe(true)
+    expect(isUserListedInArticleAuthors(user, 'No match here')).toBe(false)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes DOI/ORCID author selection and adds DataCite `PUT` updates, which can affect external metadata and who receives ORCID credit. Main risk is mismatched author parsing/substring matching causing missed or extra updates for some users/projects.
> 
> **Overview**
> Standardizes “credited author” logic across publishing/DOI/ORCID by introducing `util/article-authors-eligibility.js`, and switches `getOrcidWorkStatus` + `ORCIDWorksHandler` to use this shared check (now only pushing works when `article_authors` is non-empty).
> 
> Reworks `doi-author-service` to build DataCite creators from the parsed `article_authors` byline (preserving order, allowing external authors as name-only entries) and to fall back to a single placeholder creator when no byline is provided.
> 
> Extends `DataCiteDOICreator` with an explicit `update()` (PUT) path and adjusts JSON generation to omit `event` on updates, while `DOICreationHandler` now updates existing DOIs when present and rebuilds missing/empty author snapshots from current project data. Tests are updated/added to cover the new author parsing and create-vs-update behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cbff6d62333da4037b37e83a867becb0f217a59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->