### PR TITLE
MB4-448: pad placeholder states so AI-extracted matrices preserve cell scores

### DIFF
--- a/src/lib/matrix-import/matrix-importer.js
+++ b/src/lib/matrix-import/matrix-importer.js
@@ -974,17 +974,10 @@ function processCellValue(cellValue, params) {
         continue
       }
       
-      // Map score to state num (not array index!)
-      let stateNum
-      if (symbols && Object.keys(symbols).length > 0) {
-        stateNum = symbols[score]
-      } else if (score >= '0' && score <= '9') {
-        stateNum = parseInt(score)
-      } else {
-        stateNum = score.toUpperCase().charCodeAt(0) - 65 // A = 0, B = 1, etc.
-      }
-      
-      if (stateNum == undefined || stateNum < 0) {
+      // Map score to state num (not array index!) — shared with the
+      // padCharacterStatesToMatchScores pre-pass so both stay in sync.
+      const stateNum = resolveStateNum(score, symbols)
+      if (stateNum == null || stateNum < 0) {
         continue
       }
       

--- a/src/lib/matrix-import/matrix-importer.js
+++ b/src/lib/matrix-import/matrix-importer.js
@@ -413,6 +413,22 @@ async function importIntoMatrix(
   const gapSymbol = matrixObj.parameters?.GAP || '?'
   const symbols = parseSymbols(matrixObj.parameters?.SYMBOLS)
 
+  // MB4-448: AI extraction can return fewer state names than the MATRIX block
+  // actually uses (e.g. AI gives 2 names but cells use codes 0..3). The
+  // per-cell loop below maps `state.num === parseInt(digit)` and silently
+  // drops digits that don't match — turning real scores into `?`. Walk every
+  // cell once, find the highest state code per character, and pre-create
+  // placeholder states so every digit in the file has a target.
+  await padCharacterStatesToMatchScores({
+    matrixObj,
+    projectCharactersMap,
+    missingSymbol,
+    gapSymbol,
+    symbols,
+    transaction,
+    user,
+  })
+
   // Check if we should use batched processing for large matrices
   const taxaCount = matrixObj.taxa?.length || 0
   const charCount = matrixObj.characters?.length || 0
@@ -787,6 +803,76 @@ function parseSymbols(symbols) {
     }
   }
   return map
+}
+
+// Resolve a single character's score code to a numeric state index using the
+// same rules as processCellValue (SYMBOLS map → digit → letter offset).
+function resolveStateNum(score, symbols) {
+  if (symbols && Object.keys(symbols).length > 0) {
+    const n = symbols[score]
+    return n == null ? null : n
+  }
+  if (score >= '0' && score <= '9') return parseInt(score)
+  return score.toUpperCase().charCodeAt(0) - 65
+}
+
+async function padCharacterStatesToMatchScores({
+  matrixObj,
+  projectCharactersMap,
+  missingSymbol,
+  gapSymbol,
+  symbols,
+  transaction,
+  user,
+}) {
+  if (!matrixObj?.cells || !matrixObj?.characters) return
+
+  const maxNumByCharacter = new Map()
+  for (let x = 0; x < matrixObj.cells.length; ++x) {
+    const cellRow = matrixObj.cells[x]
+    if (!cellRow) continue
+    for (let y = 0; y < cellRow.length; ++y) {
+      const characterId = matrixObj.characters[y]?.characterId
+      if (!characterId) continue
+      const character = projectCharactersMap.get(characterId)
+      if (!character || character.type > 0) continue // skip continuous
+
+      const cellValue = cellRow[y]
+      let scores = cellValue
+      if (typeof cellValue === 'object' && cellValue !== null) {
+        scores = cellValue.scores
+      }
+      if (scores == null || scores === '') continue
+
+      for (const ch of String(scores).toUpperCase()) {
+        if (ch === missingSymbol || ch === gapSymbol || ch === '-' || ch === '–') continue
+        const stateNum = resolveStateNum(ch, symbols)
+        if (stateNum == null || stateNum < 0) continue
+        const cur = maxNumByCharacter.get(characterId) ?? -1
+        if (stateNum > cur) maxNumByCharacter.set(characterId, stateNum)
+      }
+    }
+  }
+
+  for (const [characterId, maxNum] of maxNumByCharacter) {
+    const character = projectCharactersMap.get(characterId)
+    if (!character) continue
+    const existingNums = new Set((character.states || []).map((s) => s.num))
+    for (let n = 0; n <= maxNum; ++n) {
+      if (existingNums.has(n)) continue
+      const placeholder = await models.CharacterState.create(
+        {
+          name: `State ${n}`,
+          num: n,
+          character_id: characterId,
+          user_id: user.user_id,
+        },
+        { transaction, user }
+      )
+      character.states.push(placeholder)
+    }
+    character.states.sort((a, b) => a.num - b.num)
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

When users upload a NEXUS matrix that uses state codes the AI extractor didn't return as state names (e.g. AI returns `["Trifid","bifid"]` but the matrix uses digits 0–3), the backend's per-cell `state.num === parseInt(digit)` lookup silently drops every cell that has no matching state — those scores render as `?` after upload.

This change adds a pre-pass before cell import that scans every cell, finds the highest state code each character uses, and creates placeholder `State N` rows up to that max. The existing cell loop is unchanged; it simply now finds a state for every digit and writes real cells instead of skipping them. Curators can rename the placeholder states later — net effect is data preservation, not data loss.

The frontend MB4-448 fix (mb4-web `8c8e12b`) ensures cell digits survive the AI-extract step on the client. This change is the corresponding backend half so the digits actually land in the DB.

## Test plan

- [x] Reproduced original bug on beta with `Turrilitoidea_Monks_1999.nex` + `Palaeontology - 2003 - Monks - Cladistic analysis of Albian heteromorph ammonites-1.pdf` (Tanya's reported case from MB4-448): cols 2–5 every taxon `?`.
- [x] Diagnostic script `mb4-curator/tests/test_files/diagnose_mb4_448.py --with-fix` simulates the new pre-pass against the cached AI response. Drops fall from **100 / 702 cells (14.2%) → 0 / 702**. Legit `?`/`-` cells (count 11) untouched. `node --check` passes.
- [ ] Deploy to staging (beta), upload Turrilitoidea pair, confirm cols 2–5 now show `State 2`/`State 3` placeholders instead of `?`. Other columns unchanged.
- [ ] Confirm continuous-character matrices unaffected (pre-pass skips `character.type > 0`).
- [ ] Regression: re-upload an existing matrix that previously imported cleanly — no extra placeholder states should be created (only digits beyond existing state.num trigger creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies matrix import to create additional `CharacterState` rows during ingestion based on observed cell codes; incorrect parsing or symbol handling could create unintended states or affect imported data integrity.
> 
> **Overview**
> Fixes matrix imports where cell scores reference state codes not present in AI-extracted state names by **pre-scanning all cells** and creating placeholder `CharacterState` entries (`State N`) up to the maximum state code used per discrete character.
> 
> Refactors score→state-number mapping into a shared `resolveStateNum()` helper and uses it both in the new padding pre-pass and the existing per-cell import loop, preventing valid scores from being silently dropped and rendered as missing (`?`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bddde8acb449defa66e0e536f6ec0539a3d94894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->